### PR TITLE
Handling of error in playback

### DIFF
--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -318,6 +318,7 @@ class Endpoint extends Emitter {
         }.bind(this),
         function sendPlay(callback) {
           this.execute('playback', files.join('!'), function(err, evt) {
+            if (err) return callback(err);
             const result = {
               playbackSeconds: evt.getHeader('variable_playback_seconds'),
               playbackMilliseconds: evt.getHeader('variable_playback_ms'),


### PR DESCRIPTION
Hi Dave,

We've come across an issue when doing an immediate answer and playback in certain scenarios:

```
TypeError: Cannot read property 'getHeader' of undefined
    at /opt/voice-core/node_modules/drachtio-fsmrf/lib/endpoint.js:322:36
    at __x (/opt/voice-core/node_modules/drachtio-fsmrf/lib/endpoint.js:902:31)
    at Endpoint.execute (/opt/voice-core/node_modules/drachtio-fsmrf/lib/endpoint.js:910:7)
    at Endpoint.sendPlay (/opt/voice-core/node_modules/drachtio-fsmrf/lib/endpoint.js:320:16)
    at fn (/opt/voice-core/node_modules/async/lib/async.js:746:34)
    at /opt/voice-core/node_modules/async/lib/async.js:1213:16
    at /opt/voice-core/node_modules/async/lib/async.js:166:37
    at /opt/voice-core/node_modules/async/lib/async.js:706:43
    at /opt/voice-core/node_modules/async/lib/async.js:167:37
    at Immediate.<anonymous> (/opt/voice-core/node_modules/async/lib/async.js:1206:34)
    at runCallback (timers.js:705:18)
    at tryOnImmediate (timers.js:676:5)
    at processImmediate (timers.js:658:5)
    at process.topLevelDomainCallback (domain.js:126:23)
```

Looking over [the relevant line](https://github.com/davehorton/drachtio-fsmrf/blob/bc79e46e15cda9e597875e9ea80979a08ef12b1e/lib/endpoint.js#L322), it appears an `err` object is expected but not dealt with. 

I don't know a lot of the conventions used in the drachtio libs, however I believe this should be sufficient as a patch?