### PR TITLE
Add RECV_RTCP_MESSAGE to EVENTS_OF_INTEREST

### DIFF
--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -23,6 +23,7 @@ const EVENTS_OF_INTEREST = [
   'CHANNEL_ANSWER',
   'DTMF',
   'DETECTED_TONE',
+  'RECV_RTCP_MESSAGE',
   'CUSTOM conference::maintenance'
 ];
 


### PR DESCRIPTION
Hello Dave, I needed to add this event to the list of EVENTS_OF_INTEREST In order to make it possible to catch the early media received from the callee before we bridge the call. otherwise we can play custom ringtone in the case that no media has been recieved.
Please consider the possibility to add this along with the ability to customize this list in the future to anyone's wish.
P.S. Why not just use the 'all' parameter?